### PR TITLE
Task/adds php7 xmlwriter

### DIFF
--- a/php/build/alpine-3.9/Dockerfile
+++ b/php/build/alpine-3.9/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache --update \
   php7-opcache \
   php7-phar \
   php7-tokenizer \
+  php7-xmlwriter \
   php7-xsl \
   python2 \
   rsync \


### PR DESCRIPTION
We need to add the php7 xmlwriter, because its a dependency for the php codesniffer.