### PR TITLE
adds node 10.16 to build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The images are used by our CI tools (prefixed 'build') and as base images for ou
 ### Build Images
 - [node/build/10.8.0](https://hub.docker.com/r/joblocal/base-build-node-awscli/)
 - [node/build/10.12.0](https://hub.docker.com/r/joblocal/base-build-node-awscli/)
+- [node/build/10.16](https://hub.docker.com/r/joblocal/base-build-node-awscli/)
+- [node/build/12.1.0](https://hub.docker.com/r/joblocal/base-build-node-awscli/)
 - [php/build/alpine-3.7](https://hub.docker.com/r/joblocal/base-build/)
 - [php/build/alpine-3.8](https://hub.docker.com/r/joblocal/base-build/)
 - [php/build/alpine-3.9](https://hub.docker.com/r/joblocal/base-build/)

--- a/node/build/10.16/Dockerfile
+++ b/node/build/10.16/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10.16-alpine
+
+LABEL maintainer="joblocal GmbH <produktentwicklung@joblocal.de>"
+
+RUN apk add --no-cache --update \
+  bash \
+  curl \
+  jq \
+  python3 \
+  zip
+
+RUN curl -O https://bootstrap.pypa.io/get-pip.py \
+    && python3 get-pip.py \
+    && pip install --upgrade pip \
+    && pip install awscli --upgrade
+
+RUN yarn global add @joblocal/aws-cfn-deployment


### PR DESCRIPTION
Some of our internal dependencies require node 10.16. e.g. vue-bucket-loader.

Maybe we should switch to lts-alpine in the future?