### PR TITLE
Clean the yarn cache after installing the cfn deployment CLI

### DIFF
--- a/node/build/10.12.0/Dockerfile
+++ b/node/build/10.12.0/Dockerfile
@@ -14,4 +14,5 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
     && pip install --upgrade pip \
     && pip install awscli --upgrade
 
-RUN yarn global add @joblocal/aws-cfn-deployment
+RUN yarn global add @joblocal/aws-cfn-deployment \
+    && yarn cache clean

--- a/node/build/10.16/Dockerfile
+++ b/node/build/10.16/Dockerfile
@@ -14,4 +14,5 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
     && pip install --upgrade pip \
     && pip install awscli --upgrade
 
-RUN yarn global add @joblocal/aws-cfn-deployment
+RUN yarn global add @joblocal/aws-cfn-deployment \
+    && yarn cache clean

--- a/node/build/10.8.0/Dockerfile
+++ b/node/build/10.8.0/Dockerfile
@@ -14,4 +14,5 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
     && pip install --upgrade pip \
     && pip install awscli --upgrade
 
-RUN yarn global add @joblocal/aws-cfn-deployment
+RUN yarn global add @joblocal/aws-cfn-deployment \
+    && yarn cache clean

--- a/node/build/12.1.0/Dockerfile
+++ b/node/build/12.1.0/Dockerfile
@@ -15,4 +15,5 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
     && pip install --upgrade pip \
     && pip install awscli --upgrade
 
-RUN yarn global add @joblocal/aws-cfn-deployment
+RUN yarn global add @joblocal/aws-cfn-deployment \
+    && yarn cache clean


### PR DESCRIPTION
This will improve pipeline speed, since the build image is smaller, hence the images will be pulled faster on Bitbucket Pipelines.